### PR TITLE
[BUGFIX] CRASH: index 0 beyond bounds for empty array

### DIFF
--- a/KTVCocoaHTTPServer/Classes/HTTPConnection.m
+++ b/KTVCocoaHTTPServer/Classes/HTTPConnection.m
@@ -842,9 +842,17 @@ static NSMutableArray *recentNonces;
 				// Note: The range is inclusive. So 0-1 has a length of 2 bytes.
 				
 				if(r1 > r2) return NO;
-				if(r2 >= contentLength) return NO;
-				
-				[ranges addObject:[NSValue valueWithDDRange:DDMakeRange(r1, r2 - r1 + 1)]];
+                /*
+                 modify by robbin(irobbin1024@gmail.com)
+                 old code : if(r2 >= contentLength) return NO;
+                 new code : below
+                 via : https://github.com/robbiehanson/CocoaHTTPServer/issues/78
+                 */
+                if(r2 >= contentLength) {
+                    r2 = contentLength - 1;
+                }
+                
+                [ranges addObject:[NSValue valueWithDDRange:DDMakeRange(r1, r2 - r1 + 1)]];
 			}
 		}
 	}
@@ -2516,17 +2524,23 @@ static NSMutableArray *recentNonces;
 		}
 		else
 		{
-			if (ranges == nil)
-			{
-				[self continueSendingStandardResponseBody];
-			}
-			else
-			{
-				if ([ranges count] == 1)
-					[self continueSendingSingleRangeResponseBody];
-				else
-					[self continueSendingMultiRangeResponseBody];
-			}
+            /*
+             modify by robbin(irobbin1024@gmail.com)
+             old code : if ([ranges count] < 1)
+             new code : below
+             via : https://github.com/robbiehanson/CocoaHTTPServer/issues/78
+             */
+            if (!ranges || [ranges count] < 1)
+            {
+                [self continueSendingStandardResponseBody];
+            }
+            else
+            {
+                if ([ranges count] == 1)
+                    [self continueSendingSingleRangeResponseBody];
+                else
+                    [self continueSendingMultiRangeResponseBody];
+            }
 		}
 	}});
 }


### PR DESCRIPTION
solution from robbiehanson/CocoaHTTPServer issues 87

This error has occurred in KTVHTTPCache